### PR TITLE
Change courseutils version in checker script

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,7 @@ jobs:
     
     - name: Install checker 
       run: |
-        pip install git+https://github.com/introcompsys/courseutils@main
+        pip install git+https://github.com/introcompsys/courseutils@fa22
          
         
     - name: Counter For C


### PR DESCRIPTION

this version will still work after I make updates for sp23. 

You may ignore this if you are finishing and will not run the checker after this week. 
If you are taking an incomplete this is mandatory, or your checker script will become inaccurate. 
